### PR TITLE
gcc: Mirror final gcc extra config into core gcc extra config

### DIFF
--- a/configs/common.config
+++ b/configs/common.config
@@ -19,6 +19,7 @@ CT_GDB_CUSTOM_LOCATION="${GITHUB_WORKSPACE}/gdb"
 CT_GCC_SRC_CUSTOM=y
 CT_GCC_CUSTOM_LOCATION="${GITHUB_WORKSPACE}/gcc"
 CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array"
+CT_CC_GCC_CORE_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array"
 CT_CC_LANG_CXX=y
 
 # Picolibc

--- a/configs/x86_64-zephyr-elf.config
+++ b/configs/x86_64-zephyr-elf.config
@@ -7,3 +7,4 @@ CT_TARGET_CFLAGS="-ftls-model=local-exec"
 CT_MULTILIB=y
 CT_BINUTILS_EXTRA_CONFIG_ARRAY="--enable-targets=x86_64-pep --disable-warn-rwx-segments"
 CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array --with-cpu-32=i586 --with-arch-32=i586 --with-cpu-64=generic --with-arch-64=x86-64"
+CT_CC_GCC_CORE_EXTRA_CONFIG_ARRAY="--with-gnu-ld --with-gnu-as --enable-initfini-array --with-cpu-32=i586 --with-arch-32=i586 --with-cpu-64=generic --with-arch-64=x86-64"


### PR DESCRIPTION
Make sure the core gcc is built the same way as the final gcc. This is required for x86_64, but a good idea everywhere.